### PR TITLE
Remove base64 decode of the client secret, have JWT.decode check the …

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    devise_auth0_jwt_strategy (0.0.11)
+    devise_auth0_jwt_strategy (0.0.12)
       devise (>= 3.4)
       jwt (>= 2.2.0)
       request_store (~> 1.3)

--- a/devise_auth0_jwt_strategy.gemspec
+++ b/devise_auth0_jwt_strategy.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name          = 'devise_auth0_jwt_strategy'
-  gem.version       = '0.0.11'
+  gem.version       = '0.0.12'
   gem.date          = '2015-03-10'
   gem.summary       = "Authenticate requests using an Auth0 JWT passed by HTTP header"
   gem.description   = gem.summary

--- a/lib/devise_auth0_jwt_strategy/strategy.rb
+++ b/lib/devise_auth0_jwt_strategy/strategy.rb
@@ -66,6 +66,19 @@ module Devise
         return false
       end
 
+      def decode_options
+        # We will continue doing our own claim checks just for backwards compatibility
+        {
+          verify_expiration: false,
+          verify_iat: false,
+          verify_iss: false,
+          verify_aud: false,
+          verify_jti: false,
+          verify_subj: false,
+          verify_not_before: false
+        }
+      end
+
       def authenticate!
 
         if ENV['DEBUG_AUTH0_JWT']
@@ -75,9 +88,9 @@ module Devise
         end
 
         if valid?
+          # Passing true will cause #decode to verify the token signature
           # This will throw JWT::DecodeError if it fails
-          payload, header = ::JWT.decode(@jwt_token,
-          ::JWT::Base64.url_decode(auth0_client_secret))
+          payload, header = ::JWT.decode(@jwt_token, auth0_client_secret, true, decode_options)
 
           STDERR.puts payload.inspect if ENV['DEBUG_AUTH0_JWT']
 


### PR DESCRIPTION
…token signature, and do less mocking in the tests.